### PR TITLE
修复04.js引用template.html的路径，应该是当前目录下

### DIFF
--- a/demos/04.js
+++ b/demos/04.js
@@ -4,7 +4,7 @@ const app = new Koa();
 
 const main = ctx => {
   ctx.response.type = 'html';
-  ctx.response.body = fs.createReadStream('./demos/template.html');
+  ctx.response.body = fs.createReadStream('./template.html');
 };
 
 app.use(main);


### PR DESCRIPTION
04.js 文件下的 引用 template.html 的路径 由 ./demo/template.html 改为了 ./template.html.看文件应该是当前目录下